### PR TITLE
Add required libraries for Debian 7

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -91,7 +91,7 @@ Optionally, you can install repo from homebrew as well:
 
 The following works for a clean Debian stable (squeeze) installation (under root):
 
-    aptitude install -y --without-recommends build-essential automake libtool pkg-config check libssl-dev sqlite3 libevent-dev libglib2.0-dev libcurl4-openssl-dev erlang-nox curl erlang-dev erlang-src ruby libmozjs-dev libicu-dev
+    aptitude install -y --without-recommends build-essential automake libtool pkg-config check libssl-dev sqlite3 libevent-dev libglib2.0-dev libcurl4-openssl-dev erlang-nox curl erlang-dev erlang-src ruby libmozjs-dev libicu-dev icu-config libsnappy-dev libcurl4-openssl-dev cloog-ppl libv8-dev
     aptitude install -y python-minimal
     aptitude install -y --without-recommends git-core
 


### PR DESCRIPTION
Added required libraries to the Debian install README. For a fresh Debian 7.0 install, icu-config, libsnappy-dev, cloog-ppl and libcurl4-openssl-dev are not included.

For icu-config, configure fails like so:

```
checking for icu-config... no
*** The icu-config script could not be found. Make sure it is
*** in your path, and that taglib is properly installed.
*** Or see http://ibm.com/software/globalization/icu/
configure: error: Library requirements (ICU) not met.
```

For libsnappy-dev, configure fails like so:

```
checking for libsnappy... no
configure: error: Failed to locate snappy-c.h
make: *** [couchstore/Makefile] Error 1
```

For libcurl, configure fails like so:

```
checking for libcurl... no
checking if libcurl has CURLOPT_USERNAME... no
configure: WARNING: libcurl development lib not found. On Debian this is found in libcurl4-gnutls-dev. On RHEL5/Fedora11 it's in curl-devel. On RHEL6/Fedora12 it's in libcurl-devel.
configure: error: libcurl is required for libconflate
make: *** [libconflate/Makefile] Error 1
```

For cloog-ppl, configure fails like so:

```
libmemcached/protocol/ascii_handler.c: In function 'parse_ascii_key':
libmemcached/protocol/ascii_handler.c:16:17: sorry, unimplemented: Graphite loop optimizations can only be used if the libcloog-ppl0 package is installed
libmemcached/protocol/ascii_handler.c: In function 'ascii_get_response_handler':
libmemcached/protocol/ascii_handler.c:116:1: sorry, unimplemented: Graphite loop optimizations can only be used if the libcloog-ppl0 package is installed
make[3]: *** [libmemcached/protocol/libmemcached_libmemcachedprotocol_la-ascii_handler.lo] Error 1
make[3]: Leaving directory `/root/couchbase/libmemcached'
make[2]: *** [install-recursive] Error 1
make[2]: Leaving directory `/root/couchbase/libmemcached'
make[1]: *** [install] Error 2
make[1]: Leaving directory `/root/couchbase/libmemcached'
make: *** [make-install-libmemcached] Error 2
```

For libv8, configure fails like so:

```
checking for v8.h... no
configure: error: Could not find the V8 JavaScript engine library.
make: *** [couchdb/Makefile] Error 1
```
